### PR TITLE
Deduplicate muxer for a given same stream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Same as `channel.cork` but on the muxer instance.
 
 Same as `channel.uncork` but on the muxer instance.
 
+#### `for (const channel of muxer) { ... }`
+
+The muxer instance is iterable, so you can iterate over all the channels.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -243,6 +243,9 @@ class Channel {
 
 module.exports = class Protomux {
   constructor (stream, { alloc } = {}) {
+    if (stream.protomux) return stream.protomux
+    stream.protomux = this
+
     this.isProtomux = true
     this.stream = stream
     this.corked = 0

--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ class Channel {
 
 module.exports = class Protomux {
   constructor (stream, { alloc } = {}) {
-    stream.protomux = this
+    if (stream.userData === null) stream.userData = this
 
     this.isProtomux = true
     this.stream = stream
@@ -273,7 +273,7 @@ module.exports = class Protomux {
   }
 
   static from (stream, opts) {
-    if (stream.protomux) return stream.protomux
+    if (stream.userData && stream.userData.isProtomux) return stream.userData
     if (stream.isProtomux) return stream
     return new this(stream, opts)
   }

--- a/test.js
+++ b/test.js
@@ -265,6 +265,52 @@ test('pipeline close and rejections', function (t) {
   }
 })
 
+test('deduplicate muxers', function (t) {
+  const sa = new SecretStream(true)
+  const sb = new SecretStream(false)
+
+  replicate({ stream: sa }, { stream: sb })
+
+  const a = new Protomux(sa)
+  const foo = a.createChannel({
+    protocol: 'foo',
+    onopen () { t.pass('a remote opened') }
+  })
+
+  foo.open()
+
+  foo.addMessage({
+    encoding: c.string,
+    onmessage (message) { t.is(message, 'hello foo') }
+  })
+
+  const bfoo = new Protomux(sb).createChannel({ protocol: 'foo' })
+
+  // Another Protomux instance for another protocol
+  const a2 = new Protomux(sa)
+  const bar = a2.createChannel({
+    protocol: 'bar',
+    onopen () { t.pass('a remote opened') }
+  })
+
+  bar.open()
+
+  bar.addMessage({
+    encoding: c.string,
+    onmessage (message) { t.is(message, 'hello bar') }
+  })
+
+  const bbar = new Protomux(sb).createChannel({ protocol: 'bar' })
+
+  t.plan(4)
+
+  bfoo.open()
+  bfoo.addMessage({ encoding: c.string }).send('hello foo')
+
+  bbar.open()
+  bbar.addMessage({ encoding: c.string }).send('hello bar')
+})
+
 function replicate (a, b) {
   a.stream.rawStream.pipe(b.stream.rawStream).pipe(a.stream.rawStream)
 }


### PR DESCRIPTION
Not sure if this causes any problems I can't think of, But it sure fixes this [problem](https://gist.github.com/Nazeh/a3f1d24b597913303afcb6c568f4b042) as well as the new unit test (comment out line 248 to see it fail)

This would make this [PR](https://github.com/hypercore-protocol/corestore/pull/27) unnecessary too.