### PR TITLE
Add name to channel messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ class Channel {
     if (!opts) return this._skipMessage()
 
     const type = this.messages.length
+    const name = opts.name || null
     const encoding = opts.encoding || c.raw
     const onmessage = opts.onmessage || noop
 
@@ -188,6 +189,7 @@ class Channel {
 
     const m = {
       type,
+      name,
       encoding,
       onmessage,
       recv (state, session) {
@@ -224,6 +226,7 @@ class Channel {
     }
 
     this.messages.push(m)
+    if (name) this.messages[name] = m
 
     return m
   }
@@ -232,6 +235,7 @@ class Channel {
     const type = this.messages.length
     const m = {
       type,
+      name: null,
       encoding: c.raw,
       onmessage: noop,
       recv (state, session) {},


### PR DESCRIPTION
This is not really needed but it would avoid doing this:
https://github.com/hypercore-protocol/hypercore/blob/29d2132de66b198b042a01e48d59fc2b38609ac7/lib/replicator.js#L258

With this PR we could do:
```js
const channel = mux.createChannel({
  messages: [
    { name: 'sync', encoding: c.raw, onmessage: onsync },
    { name: 'request', encoding: c.raw, onmessage: onrequest },
    ...
  ]
})

channel.messages.sync.send(...)
channel.messages.request.send(...)
```

Although, instead of that, I could do a few other changes to support this:
```js
channel.send.sync(...)
channel.send.request(...)
```
Or this:
```js
channel.send('sync', ...)
channel.send('request', ...)
```