### PR TITLE
Add hypertrace for recv and send methods in Channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,16 +197,14 @@ class Channel {
     const s = this
     const typeLen = encodingLength(c.uint, type)
 
-    const self = this
-
     const m = {
       type,
       encoding,
       onmessage,
       recv (state, session) {
-        self.tracer.trace('recv', {
-          id: self.id,
-          protocol: self.protocol,
+        s.tracer.trace('recv', {
+          id: s.id,
+          protocol: s.protocol,
           type
         })
 
@@ -215,9 +213,9 @@ class Channel {
       send (m, session = s) {
         if (session.closed === true) return false
 
-        self.tracer.trace('send', {
-          id: self.id,
-          protocol: self.protocol,
+        s.tracer.trace('send', {
+          id: s.id,
+          protocol: s.protocol,
           type
         })
 

--- a/index.js
+++ b/index.js
@@ -203,8 +203,8 @@ class Channel {
       onmessage,
       recv (state, session) {
         s.tracer.trace('recv', {
-          id: s.id,
           protocol: s.protocol,
+          id: s.id,
           type
         })
 
@@ -214,8 +214,8 @@ class Channel {
         if (session.closed === true) return false
 
         s.tracer.trace('send', {
-          id: s.id,
           protocol: s.protocol,
+          id: s.id,
           type
         })
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "b4a": "^1.3.1",
     "compact-encoding": "^2.5.1",
+    "hypertrace": "^1.4.2",
     "queue-tick": "^1.0.0",
     "safety-catch": "^1.0.1"
   },


### PR DESCRIPTION
Useful for instrumenting hypercore-related apps, to know how often each message type gets sent and received