### PR TITLE
fix(isIdle): account for null sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Same as `channel.uncork` but on the muxer instance.
 
 The muxer instance is iterable, so you can iterate over all the channels.
 
+#### `mux.isIdle()`
+
+Convenience method that returns true if the number of channels is currently 0.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -341,6 +341,10 @@ module.exports = class Protomux {
     }
   }
 
+  isIdle () {
+    return this._local.length === 0
+  }
+
   cork () {
     if (++this.corked === 1) {
       this._batch = []

--- a/index.js
+++ b/index.js
@@ -341,8 +341,13 @@ module.exports = class Protomux {
     }
   }
 
+  _sessionCount () {
+    // count the number of non-null sessions
+    return this._local.reduce((a, s) => a + (s ? 1 : 0), 0)
+  }
+
   isIdle () {
-    return this._local.length === 0
+    return this._sessionCount() === 0
   }
 
   cork () {

--- a/index.js
+++ b/index.js
@@ -341,13 +341,8 @@ module.exports = class Protomux {
     }
   }
 
-  _sessionCount () {
-    // count the number of non-null sessions
-    return this._local.reduce((a, s) => a + (s ? 1 : 0), 0)
-  }
-
   isIdle () {
-    return this._sessionCount() === 0
+    return this._local.length === this._free.length
   }
 
   cork () {


### PR DESCRIPTION
part of https://app.asana.com/0/1206774237110658/1207785530719539/f

During testing, I re-discovered why I'd used the iterator approach instead of just grabbing `._local.length` 🙃 