### PR TITLE
Unslab id

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const c = require('compact-encoding')
 const queueTick = require('queue-tick')
 const safetyCatch = require('safety-catch')
 const { createTracer } = require('hypertrace')
+const unslab = require('unslab')
 
 const MAX_BUFFERED = 32768
 const MAX_BACKLOG = Infinity // TODO: impl "open" backpressure
@@ -586,7 +587,7 @@ module.exports = class Protomux {
   _onopensession (state) {
     const remoteId = c.uint.decode(state)
     const protocol = c.string.decode(state)
-    const id = c.buffer.decode(state)
+    const id = unslab(c.buffer.decode(state))
 
     // remote tried to open the control session - auto reject for now
     // as we can use as an explicit control protocol declaration if we need to

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "compact-encoding": "^2.5.1",
     "hypertrace": "^1.4.2",
     "queue-tick": "^1.0.0",
-    "safety-catch": "^1.0.1"
+    "safety-catch": "^1.0.1",
+    "unslab": "^1.3.0"
   },
   "devDependencies": {
     "@hyperswarm/secret-stream": "^6.0.0",

--- a/test.js
+++ b/test.js
@@ -602,6 +602,12 @@ test('id unslabbed when receiving', async function (t) {
     32,
     'unslabbed id when received from remote'
   )
+
+  t.is(
+    [...a._infos.values()][0].id.buffer.byteLength,
+    32,
+    'unslabbed id when set by yourself'
+  )
 })
 
 function replicate (a, b) {

--- a/test.js
+++ b/test.js
@@ -577,6 +577,33 @@ test('isIdle - basic functionality', async function (t) {
   bp.close()
 })
 
+test('id unslabbed when receiving', async function (t) {
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  const protocol = 'foo'
+  const id = b4a.alloc(32)
+  const p = a.createChannel({
+    protocol,
+    id
+  })
+
+  p.open()
+
+  // Hack to make it not insta gc the info
+  b.pair({ protocol, id }, async () => await new Promise(resolve => setTimeout(resolve, 100)))
+
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.is(
+    [...b._infos.values()][0].id.buffer.byteLength,
+    32,
+    'unslabbed id when received from remote'
+  )
+})
+
 function replicate (a, b) {
   a.stream.rawStream.pipe(b.stream.rawStream).pipe(a.stream.rawStream)
 }


### PR DESCRIPTION
Fixes a memleak for when the id is set by the remote, which currently retains the udx buffer (~68kb).