### PR TITLE
Bump `compact-encoding` to `3.0.0` & convert `id` to `optionalBuffer`

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class Channel {
 
     c.uint.preencode(state, this._localId)
     c.string.preencode(state, this.protocol)
-    c.buffer.preencode(state, this.id)
+    c.optionalBuffer.preencode(state, this.id)
     if (this._handshake) this._handshake.preencode(state, handshake)
 
     state.buffer = this._mux._alloc(state.end)
@@ -109,7 +109,7 @@ class Channel {
     state.buffer[1] = 1
     c.uint.encode(state, this._localId)
     c.string.encode(state, this.protocol)
-    c.buffer.encode(state, this.id)
+    c.optionalBuffer.encode(state, this.id)
     if (this._handshake) this._handshake.encode(state, handshake)
 
     this._mux._write0(state.buffer)
@@ -672,7 +672,7 @@ module.exports = class Protomux {
   _onopensession(state) {
     const remoteId = c.uint.decode(state)
     const protocol = c.string.decode(state)
-    const id = unslab(c.buffer.decode(state))
+    const id = unslab(c.optionalBuffer.decode(state))
 
     // remote tried to open the control session - auto reject for now
     // as we can use as an explicit control protocol declaration if we need to

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "b4a": "^1.3.1",
-    "compact-encoding": "^2.5.1",
+    "compact-encoding": "^3.0.0",
     "queue-tick": "^1.0.0",
     "safety-catch": "^1.0.1",
     "unslab": "^1.3.0"


### PR DESCRIPTION
This bumps `compact-encoding` to [`3.0.0`](https://github.com/holepunchto/compact-encoding/pull/45) which changes how `buffer` & `binary` encoders work. Previously they support `null` as input and decoded empty buffers as `null`. Now they are strict. `optionalBuffer` is added for temporary backwards compatibility.

`id` can be `null` from omitting the `id` when creating a channel.

The `buffer` encoder is left in the batch methods because its presumed that batches always have a buffer and not `null`.