### PR TITLE
chore: add TypeScript declarations (.d.ts) for public API

### DIFF
--- a/.lunteignore
+++ b/.lunteignore
@@ -1,0 +1,2 @@
+# https://github.com/holepunchto/lunte/issues/17
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,263 @@
+// Type declarations for the holepunchto/protomux public API.
+/// <reference types="node" />
+
+/**
+ * Options for allocating buffers in a Protomux instance.
+ */
+export interface ProtomuxOptions {
+  /** Custom allocator; called with `(size)` and must return a `Buffer`. Defaults to `Buffer.allocUnsafe`. */
+  alloc?: Function
+}
+
+/**
+ * Options for creating a protocol channel.
+ */
+export interface CreateChannelOptions {
+  /** Protocol name used to match channels between peers. */
+  protocol: string
+  /** Optional binary identifier to distinguish multiple channels with the same protocol name. */
+  id?: Buffer | null
+  /** Compact-encoding codec for encoding/decoding the handshake value exchanged on open. */
+  handshake?: any
+  /** Array of message descriptors registered on channel open. */
+  messages?: Array<AddMessageOptions>
+  /** When `true`, returns `null` if a channel with this protocol+id is already open. */
+  unique?: boolean
+  /** Alternative protocol names that also match this channel. */
+  aliases?: Array<string>
+  /** Arbitrary value stored as `channel.userData`; not transmitted. */
+  userData?: any
+  /** Called with `(handshake, channel)` when the remote side opens this protocol. */
+  onopen?: Function
+  /** Called with `(isRemote, channel)` when either side closes the channel. */
+  onclose?: Function
+  /** Called with `(channel)` after `onclose` resolves and all pending promises settle. */
+  ondestroy?: Function
+  /** Called with `(channel)` when the underlying stream drains. */
+  ondrain?: Function
+}
+
+/**
+ * Options for registering a message type on a channel.
+ */
+export interface AddMessageOptions {
+  /** A compact-encoding codec. Defaults to raw binary (`c.raw`). */
+  encoding?: object
+  /** When `true`, batch replies are collected before the next tick. */
+  autoBatch?: boolean
+  /** Called with `(message, channel)` when the remote sends a message of this type. */
+  onmessage?: Function
+}
+
+/**
+ * Protocol + id selector used by pair/unpair/opened/getLastChannel.
+ */
+export interface ChannelKey {
+  /** Protocol name to match. */
+  protocol: string
+  /** Optional binary id to narrow the match. */
+  id?: Buffer | null
+}
+
+export class Protomux {
+  /**
+   * Make a new instance. `stream` should be a framed stream, preserving the messages written.
+   * @param stream - `stream` should be a framed stream, preserving the messages written.
+   * @param options - Optional configuration for the instance, such as a custom buffer allocator.
+   */
+  constructor(stream: object, options?: ProtomuxOptions)
+
+  /**
+   * Helper to accept either an existing muxer instance or a stream (which creates a new one).
+   * @param stream - A framed stream or an existing Protomux instance.
+   * @param opts - Muxer options passed through when a new instance is created.
+   * @returns The existing or newly created Protomux instance.
+   */
+  static from(stream: object, opts?: ProtomuxOptions): Protomux
+
+  /**
+   * Returns `true` if `mux` is a Protomux instance.
+   * @param mux - Value to test.
+   * @returns `true` when `mux` is a Protomux instance.
+   */
+  static isProtomux(mux: object): boolean
+
+  /**
+   * Convenience method that returns true if the number of channels is currently 0.
+   * @returns `true` if the channel count is currently zero.
+   */
+  isIdle(): boolean
+
+  /**
+   * Same as `channel.cork` but on the muxer instance.
+   */
+  cork(): void
+
+  /**
+   * Same as `channel.uncork` but on the muxer instance.
+   */
+  uncork(): void
+
+  /**
+   * Return the most recently opened channel for the given protocol and optional binary id, or `null` if none is open.
+   * @param options - Protocol name and optional binary id.
+   * @returns The most recently opened matching channel, or `null`.
+   */
+  getLastChannel(options: ChannelKey): Channel | null
+
+  /**
+   * Register a callback to be called everytime a new channel is requested.
+   * @param options - Protocol name and optional binary id to match.
+   * @param notify - Async callback called with the channel's binary id when a matching remote channel opens.
+   */
+  pair(options: ChannelKey, notify: Function): void
+
+  /**
+   * Unregisters the pair callback.
+   * @param options - Protocol name and optional binary id to deregister.
+   */
+  unpair(options: ChannelKey): void
+
+  /**
+   * Boolean that indicates if the channel is opened.
+   * @param options - Protocol name and optional binary id to check.
+   * @returns `true` when one or more matching channels are open.
+   */
+  opened(options: ChannelKey): boolean
+
+  /**
+   * Add a new protocol channel.
+   * @param options - Channel creation options.
+   * @returns The new channel, or `null` if it cannot be opened.
+   */
+  createChannel(options: CreateChannelOptions): Channel | null
+
+  /**
+   * Destroy the muxer and its underlying stream.
+   * @param err - Optional error to forward to the stream's `destroy` call.
+   */
+  destroy(err: Error): void
+
+  isProtomux: any
+
+  /**
+   * The underlying framed stream.
+   */
+  stream: object
+
+  /**
+   * Current cork depth; non-zero while the muxer is corked.
+   */
+  corked: number
+
+  /**
+   * `true` when the underlying stream's write buffer is empty.
+   */
+  drained: boolean
+}
+
+declare class Channel {
+  constructor(
+    mux: any,
+    info: any,
+    userData: any,
+    protocol: any,
+    aliases: any,
+    id: any,
+    handshake: any,
+    messages: any,
+    onopen: any,
+    onclose: any,
+    ondestroy: any,
+    ondrain: any
+  )
+
+  /**
+   * `true` when the underlying stream's write buffer is empty.
+   */
+  readonly drained: boolean
+
+  /**
+   * Resolves to `true` when the channel is fully open (both sides have exchanged open frames),
+or `false` if it closes before opening.
+   */
+  fullyOpened(): Promise<boolean>
+
+  /**
+   * Resolves when the channel has been fully destroyed (after `ondestroy` settles).
+   */
+  fullyClosed(): Promise<void>
+
+  /**
+   * Open the channel.
+   * @param handshake - Optional handshake value encoded with the handshake encoding provided to `createChannel`.
+   */
+  open(handshake?: any): void
+
+  /**
+   * Corking the protocol channel, makes it buffer messages and send them all in a batch when it uncorks.
+   */
+  cork(): void
+
+  /**
+   * Uncork and send the batch.
+   */
+  uncork(): void
+
+  /**
+   * Closes the protocol channel.
+   */
+  close(): void
+
+  /**
+   * Add/register a message type for a certain encoding. Options include:
+   * @param opts - Message options including encoding and onmessage handler.
+   * @returns Message object with a `send(data)` method for sending encoded messages.
+   */
+  addMessage(opts: AddMessageOptions): Message
+
+  userData: any
+
+  protocol: any
+
+  aliases: any
+
+  id: any
+
+  handshake: any
+
+  messages: any
+
+  opened: any
+
+  closed: any
+
+  destroyed: any
+
+  onopen: any
+
+  onclose: any
+
+  ondestroy: any
+
+  ondrain: any
+}
+
+declare class Message {
+  /**
+   * Send a message.
+   */
+  send(data: any): any
+
+  /**
+   * Function that is called when a message arrives.
+   */
+  onmessage: any
+
+  /**
+   * The encoding for this message.
+   */
+  encoding: any
+}
+
+export default Protomux

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,86 +1,84 @@
-// Type declarations for the holepunchto/protomux public API.
-/// <reference types="node" />
+import { Duplex } from 'streamx'
+import { type Encoder, type State } from 'compact-encoding'
+
+interface Stream extends Duplex {
+  userData?: unknown
+  alloc?(size: number): Uint8Array
+}
 
 /**
  * Options for allocating buffers in a Protomux instance.
  */
-export interface ProtomuxOptions {
+interface ProtomuxOptions {
   /** Custom allocator; called with `(size)` and must return a `Buffer`. Defaults to `Buffer.allocUnsafe`. */
-  alloc?: Function
+  alloc?(size: number): Uint8Array
 }
 
 /**
  * Options for creating a protocol channel.
  */
-export interface CreateChannelOptions {
+interface ChannelOptions<I = unknown, O = I> {
   /** Protocol name used to match channels between peers. */
   protocol: string
   /** Optional binary identifier to distinguish multiple channels with the same protocol name. */
-  id?: Buffer | null
+  id?: Uint8Array | null
   /** Compact-encoding codec for encoding/decoding the handshake value exchanged on open. */
-  handshake?: any
+  handshake?: Encoder<I, O> | null
   /** Array of message descriptors registered on channel open. */
-  messages?: Array<AddMessageOptions>
+  messages?: (MessageOptions<unknown, unknown> | null)[]
   /** When `true`, returns `null` if a channel with this protocol+id is already open. */
   unique?: boolean
   /** Alternative protocol names that also match this channel. */
-  aliases?: Array<string>
+  aliases?: string[]
   /** Arbitrary value stored as `channel.userData`; not transmitted. */
-  userData?: any
+  userData?: unknown
   /** Called with `(handshake, channel)` when the remote side opens this protocol. */
-  onopen?: Function
+  onopen?(handshake: O | null, channel: Channel<I, O>): void | Promise<void>
   /** Called with `(isRemote, channel)` when either side closes the channel. */
-  onclose?: Function
+  onclose?(isRemote: boolean, channel: Channel<I, O>): void | Promise<void>
   /** Called with `(channel)` after `onclose` resolves and all pending promises settle. */
-  ondestroy?: Function
+  ondestroy?(channel: Channel<I, O>): void | Promise<void>
   /** Called with `(channel)` when the underlying stream drains. */
-  ondrain?: Function
+  ondrain?(channel: Channel<I, O>): void | Promise<void>
 }
 
 /**
  * Options for registering a message type on a channel.
  */
-export interface AddMessageOptions {
+interface MessageOptions<I = Uint8Array, O = I> {
   /** A compact-encoding codec. Defaults to raw binary (`c.raw`). */
-  encoding?: object
+  encoding?: Encoder<I, O>
   /** When `true`, batch replies are collected before the next tick. */
   autoBatch?: boolean
   /** Called with `(message, channel)` when the remote sends a message of this type. */
-  onmessage?: Function
+  onmessage?(message: O, channel: Channel): void | Promise<void>
 }
 
 /**
  * Protocol + id selector used by pair/unpair/opened/getLastChannel.
  */
-export interface ChannelKey {
+interface ChannelKey {
   /** Protocol name to match. */
   protocol: string
   /** Optional binary id to narrow the match. */
-  id?: Buffer | null
+  id?: Uint8Array | null
 }
 
-export class Protomux {
+interface Protomux extends Iterable<Channel> {
+  readonly isProtomux: true
   /**
-   * Make a new instance. `stream` should be a framed stream, preserving the messages written.
-   * @param stream - `stream` should be a framed stream, preserving the messages written.
-   * @param options - Optional configuration for the instance, such as a custom buffer allocator.
+   * The underlying framed stream.
    */
-  constructor(stream: object, options?: ProtomuxOptions)
+  readonly stream: Stream
+  /**
+   * Current cork depth; non-zero while the muxer is corked.
+   */
+  readonly corked: number
 
   /**
-   * Helper to accept either an existing muxer instance or a stream (which creates a new one).
-   * @param stream - A framed stream or an existing Protomux instance.
-   * @param opts - Muxer options passed through when a new instance is created.
-   * @returns The existing or newly created Protomux instance.
+   * `true` when the underlying stream's write buffer is empty.
    */
-  static from(stream: object, opts?: ProtomuxOptions): Protomux
-
-  /**
-   * Returns `true` if `mux` is a Protomux instance.
-   * @param mux - Value to test.
-   * @returns `true` when `mux` is a Protomux instance.
-   */
-  static isProtomux(mux: object): boolean
+  drained: boolean
 
   /**
    * Convenience method that returns true if the number of channels is currently 0.
@@ -92,90 +90,75 @@ export class Protomux {
    * Same as `channel.cork` but on the muxer instance.
    */
   cork(): void
-
   /**
    * Same as `channel.uncork` but on the muxer instance.
    */
   uncork(): void
 
   /**
-   * Return the most recently opened channel for the given protocol and optional binary id, or `null` if none is open.
-   * @param options - Protocol name and optional binary id.
-   * @returns The most recently opened matching channel, or `null`.
-   */
-  getLastChannel(options: ChannelKey): Channel | null
-
-  /**
-   * Register a callback to be called everytime a new channel is requested.
-   * @param options - Protocol name and optional binary id to match.
-   * @param notify - Async callback called with the channel's binary id when a matching remote channel opens.
-   */
-  pair(options: ChannelKey, notify: Function): void
-
-  /**
-   * Unregisters the pair callback.
-   * @param options - Protocol name and optional binary id to deregister.
-   */
-  unpair(options: ChannelKey): void
-
-  /**
    * Boolean that indicates if the channel is opened.
    * @param options - Protocol name and optional binary id to check.
    * @returns `true` when one or more matching channels are open.
    */
-  opened(options: ChannelKey): boolean
+  opened(key: ChannelKey): boolean
 
   /**
    * Add a new protocol channel.
    * @param options - Channel creation options.
    * @returns The new channel, or `null` if it cannot be opened.
    */
-  createChannel(options: CreateChannelOptions): Channel | null
+  createChannel<I = unknown, O = I>(opts: ChannelOptions<I, O>): Channel<I, O> | null
+  /**
+   * Return the most recently opened channel for the given protocol and optional binary id, or `null` if none is open.
+   * @param options - Protocol name and optional binary id.
+   * @returns The most recently opened matching channel, or `null`.
+   */
+  getLastChannel(key: ChannelKey): Channel | null
+
+  /**
+   * Register a callback to be called everytime a new channel is requested.
+   * @param options - Protocol name and optional binary id to match.
+   * @param notify - Async callback called with the channel's binary id when a matching remote channel opens.
+   */
+  pair(key: ChannelKey, notify: (id: Uint8Array | null) => void | Promise<void>): void
+  /**
+   * Unregisters the pair callback.
+   * @param options - Protocol name and optional binary id to deregister.
+   */
+  unpair(key: ChannelKey): void
 
   /**
    * Destroy the muxer and its underlying stream.
    * @param err - Optional error to forward to the stream's `destroy` call.
    */
-  destroy(err: Error): void
-
-  isProtomux: any
-
-  /**
-   * The underlying framed stream.
-   */
-  stream: object
-
-  /**
-   * Current cork depth; non-zero while the muxer is corked.
-   */
-  corked: number
-
-  /**
-   * `true` when the underlying stream's write buffer is empty.
-   */
-  drained: boolean
+  destroy(err?: Error | null): void
 }
 
-declare class Channel {
-  constructor(
-    mux: any,
-    info: any,
-    userData: any,
-    protocol: any,
-    aliases: any,
-    id: any,
-    handshake: any,
-    messages: any,
-    onopen: any,
-    onclose: any,
-    ondestroy: any,
-    ondrain: any
-  )
+declare class Protomux {
+  /**
+   * Make a new instance. `stream` should be a framed stream, preserving the messages written.
+   * @param stream - `stream` should be a framed stream, preserving the messages written.
+   * @param options - Optional configuration for the instance, such as a custom buffer allocator.
+   */
+  constructor(stream: Stream, opts?: ProtomuxOptions)
+}
+
+interface Channel<I = unknown, O = I> {
+  readonly protocol: string
+  readonly aliases: string[]
+  readonly id: Uint8Array | null
+  readonly handshake: O | null
+  readonly messages: Message<unknown, unknown>[]
 
   /**
    * `true` when the underlying stream's write buffer is empty.
    */
   readonly drained: boolean
+  readonly opened: boolean
+  readonly closed: boolean
+  readonly destroyed: boolean
+
+  userData: unknown
 
   /**
    * Resolves to `true` when the channel is fully open (both sides have exchanged open frames),
@@ -192,13 +175,12 @@ or `false` if it closes before opening.
    * Open the channel.
    * @param handshake - Optional handshake value encoded with the handshake encoding provided to `createChannel`.
    */
-  open(handshake?: any): void
+  open(handshake?: I): void
 
   /**
    * Corking the protocol channel, makes it buffer messages and send them all in a batch when it uncorks.
    */
   cork(): void
-
   /**
    * Uncork and send the batch.
    */
@@ -214,50 +196,59 @@ or `false` if it closes before opening.
    * @param opts - Message options including encoding and onmessage handler.
    * @returns Message object with a `send(data)` method for sending encoded messages.
    */
-  addMessage(opts: AddMessageOptions): Message
+  addMessage<MI = Uint8Array, MO = MI>(opts?: MessageOptions<MI, MO> | null): Message<MI, MO>
 
-  userData: any
-
-  protocol: any
-
-  aliases: any
-
-  id: any
-
-  handshake: any
-
-  messages: any
-
-  opened: any
-
-  closed: any
-
-  destroyed: any
-
-  onopen: any
-
-  onclose: any
-
-  ondestroy: any
-
-  ondrain: any
+  onopen(handshake: O | null, channel: Channel<I, O>): void | Promise<void>
+  onclose(isRemote: boolean, channel: Channel<I, O>): void | Promise<void>
+  ondestroy(channel: Channel<I, O>): void | Promise<void>
+  ondrain(channel: Channel<I, O>): void | Promise<void>
 }
 
-declare class Message {
+interface Message<I = Uint8Array, O = I> {
+  readonly type: number
+  readonly autoBatch: boolean
   /**
-   * Send a message.
+   * The encoding for this message.
    */
-  send(data: any): any
+  readonly encoding: Encoder<I, O>
 
   /**
    * Function that is called when a message arrives.
    */
-  onmessage: any
+  onmessage(message: O, channel: Channel): void | Promise<void>
 
   /**
-   * The encoding for this message.
+   * Send a message.
    */
-  encoding: any
+  send(message: I, channel?: Channel): boolean
+  recv(state: State, channel: Channel): Promise<void> | null
 }
 
-export default Protomux
+declare namespace Protomux {
+  /**
+   * Helper to accept either an existing muxer instance or a stream (which creates a new one).
+   * @param stream - A framed stream or an existing Protomux instance.
+   * @param opts - Muxer options passed through when a new instance is created.
+   * @returns The existing or newly created Protomux instance.
+   */
+  export function from(stream: Stream | Protomux, opts?: ProtomuxOptions): Protomux
+
+  /**
+   * Returns `true` if `mux` is a Protomux instance.
+   * @param mux - Value to test.
+   * @returns `true` when `mux` is a Protomux instance.
+   */
+  export function isProtomux(mux: unknown): mux is Protomux
+
+  export {
+    type Stream,
+    type ProtomuxOptions,
+    type ChannelKey,
+    type Channel,
+    type ChannelOptions,
+    type Message,
+    type MessageOptions
+  }
+}
+
+export = Protomux

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "3.11.0",
   "description": "Multiplex multiple message oriented protocols over a stream",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "dependencies": {
     "b4a": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "b4a": "^1.3.1",
-    "compact-encoding": "^3.0.0",
+    "compact-encoding": "^3.3.2",
     "queue-tick": "^1.0.0",
     "safety-catch": "^1.0.1",
     "unslab": "^1.3.0"
@@ -20,7 +20,8 @@
     "brittle": "^3.0.0",
     "lunte": "^1.0.0",
     "prettier": "^3.6.2",
-    "prettier-config-holepunch": "^2.0.0"
+    "prettier-config-holepunch": "^2.0.0",
+    "streamx": "^2.28.1"
   },
   "scripts": {
     "format": "prettier --write .",

--- a/test.js
+++ b/test.js
@@ -433,7 +433,7 @@ test('deduplicate muxers', function (t) {
   bbar.addMessage({ encoding: c.string }).send('hello bar')
 })
 
-test('open + send + close on same tick', async function (t) {
+test('open + send + close on same tick', function (t) {
   t.plan(4)
 
   const a = new Protomux(new SecretStream(true))
@@ -535,7 +535,7 @@ test('keep alive - one side only', function (t) {
   setTimeout(() => t.pass(), 500)
 })
 
-test('isIdle - basic functionality', async function (t) {
+test('isIdle - basic functionality', function (t) {
   t.plan(8)
 
   const a = new Protomux(new SecretStream(true))
@@ -604,7 +604,7 @@ test('id unslabbed when receiving', async function (t) {
   t.is([...a._infos.values()][0].id.buffer.byteLength, 32, 'unslabbed id when set by yourself')
 })
 
-test('supports setting userData after `.createChannel()` but before `.open()`', async function (t) {
+test('supports setting userData after `.createChannel()` but before `.open()`', function (t) {
   // This test showcases why `_fullyOpenSoon()` queues `_fullyOpen()` to defer it running
   t.plan(1)
   const a = new Protomux(new SecretStream(true))
@@ -621,7 +621,7 @@ test('supports setting userData after `.createChannel()` but before `.open()`', 
 
   p.userData = true
 
-  b.pair({ protocol, id }, async () => {
+  b.pair({ protocol, id }, () => {
     const p2 = b.createChannel({
       protocol,
       id,


### PR DESCRIPTION
Adds a standalone `index.d.ts` declaring the public API — typed signatures, JSDoc-style `@param`/`@returns` doc comments, and interfaces for option shapes — instead of inline source JSDoc. Wires `types`/`files` in `package.json` so the declarations publish. This powers generated reference docs in the Pear docs site — keeping docs in sync with source.

Companion docs-site PR: holepunchto/pear-docs#315 (merged)
