### PR TITLE
fix: skip closed entries when matching an incoming open

### DIFF
--- a/index.js
+++ b/index.js
@@ -693,14 +693,17 @@ module.exports = class Protomux {
       throw new Error('Invalid open message')
     }
 
-    if (info.outgoing.length > 0) {
+    while (info.outgoing.length > 0) {
       const localId = info.outgoing.shift()
       const session = this._local[localId - 1]
 
       if (session === null) {
-        // we already closed the channel - ignore
+        // the local channel closed while its open was in flight (a close/open
+        // crossing) - skip the stale entry instead of consuming the remote's
+        // open against it, otherwise the remote ends up with a half-open
+        // channel it believes was delivered
         this._free.push(localId - 1)
-        return null
+        continue
       }
 
       this._remote[rid] = { state, pending: null, session: null }

--- a/test.js
+++ b/test.js
@@ -674,6 +674,55 @@ test('incoming onopen runs after the pair callback finishes', function (t) {
     t.ok(opened, 'onopen fired after the pair callback finished')
   })
 })
+test('an open is not consumed by an already-closed outgoing entry', function (t) {
+  t.plan(1)
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  // b opens a channel and closes it before the remote's open arrives, then
+  // opens a replacement: a's in-flight open must pair with the replacement,
+  // not be consumed by the closed channel's stale outgoing entry
+  const b1 = b.createChannel({ protocol: 'foo' })
+  b1.open()
+  b1.close()
+
+  const b2 = b.createChannel({
+    protocol: 'foo',
+    onopen() {
+      t.pass('replacement channel opened')
+    }
+  })
+  b2.open()
+
+  const a1 = a.createChannel({ protocol: 'foo' })
+  a1.open()
+})
+
+test('an open falls through to pair() when the only outgoing entry is closed', function (t) {
+  t.plan(1)
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  // b closed its only channel while a's open was in flight: the open should
+  // be delivered through pairing, like any other unsolicited open
+  b.pair({ protocol: 'foo' }, function () {
+    t.pass('pair notified for the crossed open')
+  })
+
+  const b1 = b.createChannel({ protocol: 'foo' })
+  b1.open()
+  b1.close()
+
+  const a1 = a.createChannel({ protocol: 'foo' })
+  a1.open()
+})
+
 function replicate(a, b) {
   a.stream.rawStream.pipe(b.stream.rawStream).pipe(a.stream.rawStream)
 }


### PR DESCRIPTION
When a channel is opened and then closed before the other side's open arrives, a local entry is queued in `info.outgoing` but it's not removed on close. If a replacement channel is then opened, the pairing logic gets the stale entry from `info.outgoing` and silently swallows it without triggering `onopen`, so the replacement channel just hangs without opening.

Failing tests in f8655f9288c1a765c9c689c5099b5383e46af818, followed by fix.

This could happen in practice when both sides of a connection close and re-open a channel at nearly the same time. Hypercore users would probably see this if both sides toggle replication off and on and the replication session would never complete its handshake.